### PR TITLE
Bugfix/datepicker

### DIFF
--- a/src/components/Subset.jsx
+++ b/src/components/Subset.jsx
@@ -58,8 +58,8 @@ export const SubsetPreview = ({subset}) => {
     // FIXME: show title in selected language, not just first in the name array.
     // TODO: show subset in other languages - switch button for language?
 
-    const from = subset.validFrom instanceof Date ? subset.validFrom.toISOString().substr(0, 10) : subset.validFrom;
-    const to = subset.validUntil instanceof Date ? subset.validUntil.toISOString().substr(0, 10) : subset.validUntil;
+    const from = subset.validFrom?.toISOString().substr(0, 10);
+    const to = subset.validUntil?.toISOString().substr(0, 10);
 
     return (
         <>

--- a/src/components/Subset.jsx
+++ b/src/components/Subset.jsx
@@ -58,8 +58,8 @@ export const SubsetPreview = ({subset}) => {
     // FIXME: show title in selected language, not just first in the name array.
     // TODO: show subset in other languages - switch button for language?
 
-    const from = subset.validFrom instanceof Date ? subset.validFrom?.toISOString().substr(0, 10) : subset.validFrom;
-    const to = subset.validUntil instanceof Date ? subset.validUntil?.toISOString().substr(0, 10) : subset.validUntil;
+    const from = subset.validFrom instanceof Date ? subset.validFrom.toISOString().substr(0, 10) : subset.validFrom;
+    const to = subset.validUntil instanceof Date ? subset.validUntil.toISOString().substr(0, 10) : subset.validUntil;
 
     return (
         <>

--- a/src/components/Subset.jsx
+++ b/src/components/Subset.jsx
@@ -58,8 +58,14 @@ export const SubsetPreview = ({subset}) => {
     // FIXME: show title in selected language, not just first in the name array.
     // TODO: show subset in other languages - switch button for language?
 
-    const from = subset.validFrom?.toISOString().substr(0, 10);
-    const to = subset.validUntil?.toISOString().substr(0, 10);
+    const from = subset.validFrom;
+    const to = subset.validUntil;
+    if (from instanceof Date){
+        from = subset.validFrom?.toISOString().substr(0, 10);
+    }
+    if (to instanceof Date){
+        to = subset.validUntil?.toISOString().substr(0, 10);
+    }
 
     return (
         <>

--- a/src/components/Subset.jsx
+++ b/src/components/Subset.jsx
@@ -58,14 +58,8 @@ export const SubsetPreview = ({subset}) => {
     // FIXME: show title in selected language, not just first in the name array.
     // TODO: show subset in other languages - switch button for language?
 
-    const from = subset.validFrom;
-    const to = subset.validUntil;
-    if (from instanceof Date){
-        from = subset.validFrom?.toISOString().substr(0, 10);
-    }
-    if (to instanceof Date){
-        to = subset.validUntil?.toISOString().substr(0, 10);
-    }
+    const from = subset.validFrom instanceof Date ? subset.validFrom?.toISOString().substr(0, 10) : subset.validFrom;
+    const to = subset.validUntil instanceof Date ? subset.validUntil?.toISOString().substr(0, 10) : subset.validUntil;
 
     return (
         <>

--- a/src/components/subsetDraft/SubsetCodes.jsx
+++ b/src/components/subsetDraft/SubsetCodes.jsx
@@ -16,8 +16,14 @@ export const SubsetCodes = ({subset}) => {
     const {classifications} = useContext(AppContext);
     const { t } = useTranslation();
 
-    const from = subset.draft.validFrom?.toISOString().substr(0, 10);
-    const to = subset.draft.validUntil?.toISOString().substr(0, 10);
+    const from = subset.draft.validFrom;
+    const to = subset.draft.validUntil;
+    if (from instanceof Date){
+        from = subset.draft.validFrom?.toISOString().substr(0, 10);
+    }
+    if (to instanceof Date){
+        to = subset.draft.validUntil?.toISOString().substr(0, 10);
+    }
 
     const [searchValues, setSearchValues] = useState([]); // list of classification names
     const [searchResult, setSearchResult] = useState([]); // list of classifications with codes found

--- a/src/components/subsetDraft/SubsetCodes.jsx
+++ b/src/components/subsetDraft/SubsetCodes.jsx
@@ -3,7 +3,7 @@ import {Search} from '../../utils/Search';
 import {AppContext} from '../../controllers/context';
 import {Title} from '@statisticsnorway/ssb-component-library';
 import {Classification} from './Classification';
-import {useTranslation} from "react-i18next";
+import {useTranslation} from 'react-i18next';
 
 
 /*

--- a/src/components/subsetDraft/SubsetCodes.jsx
+++ b/src/components/subsetDraft/SubsetCodes.jsx
@@ -15,8 +15,7 @@ import {useTranslation} from "react-i18next";
 export const SubsetCodes = ({subset}) => {
     const {classifications} = useContext(AppContext);
     const { t } = useTranslation();
-
-
+    
     const from = subset.draft.validFrom instanceof Date ? subset.draft.validFrom.toISOString().substr(0, 10) : subset.draft.validFrom;
     const to = subset.draft.validUntil instanceof Date ? subset.draft.validUntil.toISOString().substr(0, 10) : subset.draft.validUntil;
 

--- a/src/components/subsetDraft/SubsetCodes.jsx
+++ b/src/components/subsetDraft/SubsetCodes.jsx
@@ -17,8 +17,8 @@ export const SubsetCodes = ({subset}) => {
     const { t } = useTranslation();
 
 
-    const from = subset.draft.validFrom instanceof Date ? subset.draft.validFrom?.toISOString().substr(0, 10) : subset.draft.validFrom;
-    const to = subset.draft.validUntil instanceof Date ? subset.draft.validUntil?.toISOString().substr(0, 10) : subset.draft.validUntil;
+    const from = subset.draft.validFrom instanceof Date ? subset.draft.validFrom.toISOString().substr(0, 10) : subset.draft.validFrom;
+    const to = subset.draft.validUntil instanceof Date ? subset.draft.validUntil.toISOString().substr(0, 10) : subset.draft.validUntil;
 
     const [searchValues, setSearchValues] = useState([]); // list of classification names
     const [searchResult, setSearchResult] = useState([]); // list of classifications with codes found

--- a/src/components/subsetDraft/SubsetCodes.jsx
+++ b/src/components/subsetDraft/SubsetCodes.jsx
@@ -16,14 +16,9 @@ export const SubsetCodes = ({subset}) => {
     const {classifications} = useContext(AppContext);
     const { t } = useTranslation();
 
-    const from = subset.draft.validFrom;
-    const to = subset.draft.validUntil;
-    if (from instanceof Date){
-        from = subset.draft.validFrom?.toISOString().substr(0, 10);
-    }
-    if (to instanceof Date){
-        to = subset.draft.validUntil?.toISOString().substr(0, 10);
-    }
+
+    const from = subset.draft.validFrom instanceof Date ? subset.draft.validFrom?.toISOString().substr(0, 10) : subset.draft.validFrom;
+    const to = subset.draft.validUntil instanceof Date ? subset.draft.validUntil?.toISOString().substr(0, 10) : subset.draft.validUntil;
 
     const [searchValues, setSearchValues] = useState([]); // list of classification names
     const [searchResult, setSearchResult] = useState([]); // list of classifications with codes found

--- a/src/components/subsetDraft/SubsetCodes.jsx
+++ b/src/components/subsetDraft/SubsetCodes.jsx
@@ -16,8 +16,8 @@ export const SubsetCodes = ({subset}) => {
     const {classifications} = useContext(AppContext);
     const { t } = useTranslation();
     
-    const from = subset.draft.validFrom instanceof Date ? subset.draft.validFrom.toISOString().substr(0, 10) : subset.draft.validFrom;
-    const to = subset.draft.validUntil instanceof Date ? subset.draft.validUntil.toISOString().substr(0, 10) : subset.draft.validUntil;
+    const from = subset.draft.validFrom?.toISOString().substr(0, 10);
+    const to = subset.draft.validUntil?.toISOString().substr(0, 10);
 
     const [searchValues, setSearchValues] = useState([]); // list of classification names
     const [searchResult, setSearchResult] = useState([]); // list of classifications with codes found

--- a/src/components/subsetDraft/SubsetMetadata.jsx
+++ b/src/components/subsetDraft/SubsetMetadata.jsx
@@ -37,8 +37,8 @@ export const SubsetMetadata = ({subset}) => {
                     <label style={{display: 'block', fontSize: '16px', fontFamily: 'Roboto'}}
                            htmlFor="from_date">{t('Valid from')}: </label>
                     <input type="date" id='from_date' style={{display: 'block'}}
-                                value={subset.draft.validFrom}
-                                onChange={(e) => subset.dispatch({action: 'from', data: e.target.value})}
+                                value={subset.draft.validFrom?.toISOString().substr(0, 10)}
+                                onChange={(e) => subset.dispatch({action: 'from', data: new Date(e.target.value.split("-")[0], e.target.value.split("-")[1], e.target.value.split("-")[2])})}
                                 className='datepicker'/>
                 </div>
 
@@ -46,8 +46,8 @@ export const SubsetMetadata = ({subset}) => {
                     <label style={{display: 'block', fontSize: '16px', fontFamily: 'Roboto'}}
                            htmlFor="to_date">{t('Valid to')}: </label>
                     <input type="date" id='to_date' style={{display: 'block'}}
-                                value={subset.draft.validUntil}
-                                onChange={(e) => subset.dispatch({action: 'to', data: e.target.value})}
+                                value={subset.draft.validUntil?.toISOString().substr(0, 10)}
+                                onChange={(e) => subset.dispatch({action: 'to', data: new Date(e.target.value.split("-")[0], e.target.value.split("-")[1], e.target.value.split("-")[2])})}
                                 className='datepicker'/>
                 </div>
                 <br style={{clear: 'both'}}/>

--- a/src/components/subsetDraft/SubsetMetadata.jsx
+++ b/src/components/subsetDraft/SubsetMetadata.jsx
@@ -5,7 +5,7 @@ import {AppContext} from '../../controllers/context';
 import {languages, subsetDraft} from '../../controllers/defaults';
 import {Title} from '@statisticsnorway/ssb-component-library';
 import DatePicker from 'react-date-picker';
-import {useTranslation} from "react-i18next";
+import {useTranslation} from 'react-i18next';
 
 /*
  *  TODO: select components (2) from the ssb-component-library
@@ -35,22 +35,22 @@ export const SubsetMetadata = ({subset}) => {
             <section style={{margin: '5px 0 5px 0'}}>
                 <div style={{float: 'left', marginRight: '20px', padding: '0'}}>
                     <label style={{display: 'block', fontSize: '16px', fontFamily: 'Roboto'}}
-                           htmlFor="from_date">{t('Valid from')}: </label>
-                    <input type="date" id='from_date' style={{display: 'block'}}
+                           htmlFor='from_date'>{t('Valid from')}: </label>
+                    <input type='date' id='from_date' style={{display: 'block'}}
                                 value={subset.draft.validFrom?.toISOString().substr(0, 10)}
                                 onChange={(e) => {
-                                    const dateArr = e.target.value.split("-");
+                                    const dateArr = e.target.value.split('-');
                                     subset.dispatch({action: 'from', data: new Date(dateArr[0], dateArr[1], dateArr[2])});}}
                                 className='datepicker'/>
                 </div>
 
                 <div style={{float: 'left'}}>
                     <label style={{display: 'block', fontSize: '16px', fontFamily: 'Roboto'}}
-                           htmlFor="to_date">{t('Valid to')}: </label>
-                    <input type="date" id='to_date' style={{display: 'block'}}
+                           htmlFor='to_date'>{t('Valid to')}: </label>
+                    <input type='date' id='to_date' style={{display: 'block'}}
                                 value={subset.draft.validUntil?.toISOString().substr(0, 10)}
                            onChange={(e) => {
-                               const dateArr = e.target.value.split("-");
+                               const dateArr = e.target.value.split('-');
                                subset.dispatch({action: 'to', data: new Date(dateArr[0], dateArr[1], dateArr[2])});}}
                            className='datepicker'/>
                 </div>

--- a/src/components/subsetDraft/SubsetMetadata.jsx
+++ b/src/components/subsetDraft/SubsetMetadata.jsx
@@ -38,7 +38,9 @@ export const SubsetMetadata = ({subset}) => {
                            htmlFor="from_date">{t('Valid from')}: </label>
                     <input type="date" id='from_date' style={{display: 'block'}}
                                 value={subset.draft.validFrom?.toISOString().substr(0, 10)}
-                                onChange={(e) => subset.dispatch({action: 'from', data: new Date(e.target.value.split("-")[0], e.target.value.split("-")[1], e.target.value.split("-")[2])})}
+                                onChange={(e) => {
+                                    const dateArr = e.target.value.split("-");
+                                    subset.dispatch({action: 'from', data: new Date(dateArr[0], dateArr[1], dateArr[2])});}}
                                 className='datepicker'/>
                 </div>
 
@@ -47,8 +49,10 @@ export const SubsetMetadata = ({subset}) => {
                            htmlFor="to_date">{t('Valid to')}: </label>
                     <input type="date" id='to_date' style={{display: 'block'}}
                                 value={subset.draft.validUntil?.toISOString().substr(0, 10)}
-                                onChange={(e) => subset.dispatch({action: 'to', data: new Date(e.target.value.split("-")[0], e.target.value.split("-")[1], e.target.value.split("-")[2])})}
-                                className='datepicker'/>
+                           onChange={(e) => {
+                               const dateArr = e.target.value.split("-");
+                               subset.dispatch({action: 'to', data: new Date(dateArr[0], dateArr[1], dateArr[2])});}}
+                           className='datepicker'/>
                 </div>
                 <br style={{clear: 'both'}}/>
             </section>

--- a/src/components/subsetDraft/SubsetMetadata.jsx
+++ b/src/components/subsetDraft/SubsetMetadata.jsx
@@ -36,24 +36,18 @@ export const SubsetMetadata = ({subset}) => {
                 <div style={{float: 'left', marginRight: '20px', padding: '0'}}>
                     <label style={{display: 'block', fontSize: '16px', fontFamily: 'Roboto'}}
                            htmlFor="from_date">{t('Valid from')}: </label>
-                    <DatePicker id='from_date' style={{display: 'block'}}
+                    <input type="date" id='from_date' style={{display: 'block'}}
                                 value={subset.draft.validFrom}
-                                onChange={(date) => subset.dispatch({action: 'from', data: date})}
-                                clearIcon={null}
-                                format='dd.MM.y'
-                                locale={languages.find(i => i.default).IETF}
+                                onChange={(e) => subset.dispatch({action: 'from', data: e.target.value})}
                                 className='datepicker'/>
                 </div>
 
                 <div style={{float: 'left'}}>
                     <label style={{display: 'block', fontSize: '16px', fontFamily: 'Roboto'}}
                            htmlFor="to_date">{t('Valid to')}: </label>
-                    <DatePicker id='to_date' style={{display: 'block'}}
+                    <input type="date" id='to_date' style={{display: 'block'}}
                                 value={subset.draft.validUntil}
-                                onChange={(date) => subset.dispatch({action: 'to', data: date})}
-                                clearIcon={null}
-                                format='dd.MM.y'
-                                locale={languages.find(i => i.default).IETF}
+                                onChange={(e) => subset.dispatch({action: 'to', data: e.target.value})}
                                 className='datepicker'/>
                 </div>
                 <br style={{clear: 'both'}}/>


### PR DESCRIPTION
went back to vanilla input type="date"

The value passed from input type="date" is originally a string on form "YYYY-MM-DD", not a Date(), so I create a new Date object from splitting the string value.

At first I tried passing and using the string from the input element directly in subset.validFrom and validUntil, but then the subset refuses to be submitted (in the final screen with the overview, the submit button does nothing). So I guessed the validFrom and validUntil fields need to be Dates for the submission to work.