### PR TITLE
always focus search

### DIFF
--- a/src/utils/Search.jsx
+++ b/src/utils/Search.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import '../css/autosuggest.css';
 import { Search as SearchIcon } from 'react-feather';
 
@@ -58,6 +58,10 @@ export const Search = ({ resource = [],
             <span>{origin.substr(i + substring.length, origin.length)}</span>
         </>;
     }
+
+    useEffect(() => {
+        dom.current.focus();
+    });
 
     // TODO: convert divs to list items (li)
     // FIXME: scroll and limit amount of suggestion shown by screen size


### PR DESCRIPTION
As of now, whenever there is a search bar on a page, it is also the first thing a user wants to do on that page. I think it would be best if search bars are automatically focused (That is at least what would make the page fastest+easiest to use). This PR makes it so.  It also happens to fix the fact that the focus goes to the bottom of the search page instead of the top.

CONS:
- This solution will be wrong if we at some point build pages where there is a search bar that should for some reason not be the autofocus. The best way of autofocusing search that will not break later might be to get a list of all input items on the page, and set focus to the input item that is highest up on the screen. IDK how practical that is in React. I guess we could make a field for "first input" in the context, and all input components check if that field is empty upon their own creation, and if it is empty they set them selves to be the "first input" and then .focus themselves.
- This solution "fixes" one weird bug ( issue #83: the bottom of the page focus automatically in some cases), by solving a different problem. The most "correct" way of fixing issue #83 is to find and eliminate the weirdness that causes focus to go to the bottom of the page on some pages, so it will always just go to the top of the page like normal. How and why could that happen in react, unless someone is setting the focus there using .focus()? That could take a lot of research to find out for me, since I don't understand React well yet.


So @alina-lapina , is it worth making a new separate issue out of autofocusing the topmost input field, so people don't have to TAB-TAB-TAB-TAB or click it to enter sometihng? Should we go about attacking #83 by finding out what causes the wrong behavior, instead of working around it like I do here?

closes #83 