### PR TITLE
github logo link in footer

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,4 +1,5 @@
 import {
+    GitHub,
     Facebook,
     Linkedin,
     Rss,
@@ -30,6 +31,7 @@ export default function Footer() {
             <Link href="https://www.ssb.no/nettstedskart" isExternal negative>{t('Site map')}</Link>
         </div>
         <div className="social-links">
+            <Link href="https://github.com/statisticsnorway/klass-subsets-client" isExternal negative icon={<GitHub size={24} />} />
             <Link href="https://www.facebook.com/statistisksentralbyra/" isExternal negative icon={<Facebook size={24} />} />
             <Link href="https://twitter.com/ssbnytt" isExternal negative icon={<Twitter size={24} />} />
             <Link href="https://www.linkedin.com/company/statistics-norway/" isExternal negative icon={<Linkedin size={24} />} />

--- a/src/components/pages/WelcomePage.jsx
+++ b/src/components/pages/WelcomePage.jsx
@@ -19,14 +19,6 @@ export default function WelcomePage() {
            >{t('Issues')}</a>
            </Paragraph>
 
-           <Title size={2}>{t('Source code')}</Title>
-           <Paragraph>{t('You can find the source code on')} <a
-               className='App-link'
-               href='https://github.com/statisticsnorway/klass-subsets-web'
-               target='_blank'
-               rel='noopener noreferrer'
-           >GitHub repository</a></Paragraph>
-
            <Title size={2}>{t('Changelog')}</Title>
            <Title size={4}>v0.2.4</Title>
            <Paragraph>{t('Better codes and notes fetching')}</Paragraph>


### PR DESCRIPTION
Deleted paragraph with source link from the page Endringslogg.

Added GitHub logo button/link in footer.

closes #73 