### PR TITLE
#54 show focus outline on the button

### DIFF
--- a/src/css/tooltip.css
+++ b/src/css/tooltip.css
@@ -1,11 +1,7 @@
 .tooltip {
     position: relative;
     display: inline-block;
-    border-bottom: 1px dotted #274247;
 }
-/*.tooltip:focus {
-    outline: none;
-}*/
 
 .tooltip .tooltiptext {
     visibility: hidden;

--- a/src/utils/list.jsx
+++ b/src/utils/list.jsx
@@ -12,8 +12,15 @@ export const List = ({list}) => {
             <div style={{display: 'relative', width: '600px', padding: '5px', position: 'relative'}}>
                 <h6 style={{display: 'inline-block', width: '60px', marginBlockEnd: '0'}}>{t('Code')}</h6>
                 <h6 style={{display: 'inline', marginBlockEnd: '0'}}>{t('Code name')}</h6>
-                <h6 className='rank-text-tooltip tooltip' style={{display: 'inline', position: 'absolute', ariaLabel: 'notifications-label-rank', right: '45px', marginBlockEnd: '0'}}>{t('Rank')}
-                <span className="rank-tooltip tooltiptext" role="tooltip" id='notifications-label-rank'>{t('Code rank tooltip')}</span>
+                <h6 className='rank-text-tooltip tooltip' style={{
+                    display: 'inline',
+                    position: 'absolute',
+                    ariaLabel: 'notifications-label-rank',
+                    right: '45px',
+                    marginBlockEnd: '0',
+                    borderBottom: '1px dotted #274247'
+                }}>{t('Rank')}
+                <span className="rank-tooltip tooltiptext"  role="tooltip" id='notifications-label-rank'>{t('Code rank tooltip')}</span>
                 </h6>
             </div>
             <ul className='list' style={{paddingInlineStart: '0'}}>

--- a/src/utils/navigation.jsx
+++ b/src/utils/navigation.jsx
@@ -25,8 +25,8 @@ export const ProgressBar = ({steps, handleClick, activeStep}) => {
     return (
         <div style={{textAlign: 'center', width: '60%'}}>
             {steps.map((step, index) => (
-                <button key={index}
-                        className='tooltip'
+                <div className='tooltip'>
+                    <button key={index}
                         onClick={ () => handleClick(index) }
                         style={{
                             borderRadius: '50%',
@@ -40,9 +40,12 @@ export const ProgressBar = ({steps, handleClick, activeStep}) => {
                             margin: '0 30px 0 0',
                             ariaLabel: `notifications-label-${index}`
                         }}
-                >{index}
-                    <span className="tooltiptext" role="tooltip" id={`notifications-label${index}`}>{step.props.label}</span>
-                </button>
+                        >{index}
+                    </button>
+                    <span className="tooltiptext" style={{ borderBottom: '1px dotted #274247'}}
+                          role="tooltip"
+                          id={`notifications-label${index}`}>{step.props.label}</span>
+                </div>
             ))}
         </div>
     );


### PR DESCRIPTION
The app has to have visible focus outline on all elements, including navigation buttons.
ref issue #54 