### PR TITLE
scroll to top when next or prev clicked

### DIFF
--- a/src/utils/navigation.jsx
+++ b/src/utils/navigation.jsx
@@ -56,12 +56,12 @@ export const PrevNext = ({min, max, handleClick}) => {
 
     const next = () => {
         handleClick((state) => (state+1));
-        window.scrollTo(0, 0)
+        window.scrollTo(0, 0);
     };
 
     const prev = () => {
         handleClick((state) => (state-1));
-        window.scrollTo(0, 0)
+        window.scrollTo(0, 0);
     };
 
     // TODO: place buttons on the same place on the each step page -> on the side, not bottom

--- a/src/utils/navigation.jsx
+++ b/src/utils/navigation.jsx
@@ -56,10 +56,12 @@ export const PrevNext = ({min, max, handleClick}) => {
 
     const next = () => {
         handleClick((state) => (state+1));
+        window.scrollTo(0, 0)
     };
 
     const prev = () => {
         handleClick((state) => (state-1));
+        window.scrollTo(0, 0)
     };
 
     // TODO: place buttons on the same place on the each step page -> on the side, not bottom


### PR DESCRIPTION
As described in issue #83, the user expects to see the top of the page after the next button is clicked. We have had a discussion of where the focus should be and whether to implement new next/prev button styles, but these discussions are secondary to the issue as reported by the user: When i click next, i expect to see the top of the page.

This PR fixes exactly that problem, as reported. No more, no less. I suggest we implement this change for now. 

Setting focus to top of page/progress bar when the "next"/"prev" buttons are clicked, and changing button styles, should be treated as a separate issues and discussions, because they are not requested by the user as part of issue #83. AFAIK, setting the focus to the progress bar will not scroll the page all the way up, only up until the progress bar, which is not what is requested. Scrolling all the way up therefore has to be done manually like this regardless, if that is what the user wants.

closes #83