### PR TITLE
Feature/administrartive detail origin

### DIFF
--- a/src/components/subsetDraft/Classification.jsx
+++ b/src/components/subsetDraft/Classification.jsx
@@ -10,7 +10,7 @@ import {
     XSquare
 } from 'react-feather';
 import {Paragraph, Text, Title} from '@statisticsnorway/ssb-component-library';
-import {useGet, useClassification} from '../../controllers/klass-api';
+import {useGet, useClassification, URN} from '../../controllers/klass-api';
 import '../../css/panel.css';
 import {useTranslation} from 'react-i18next';
 import {replaceRefWithHTMLAndSanitize} from '../../utils/strings';
@@ -18,7 +18,9 @@ import {replaceRefWithHTMLAndSanitize} from '../../utils/strings';
 export const Classification = ({item = {}, update, remove, from, to}) => {
     const {t} = useTranslation();
 
-    item.id = item._links.self.href.split('/').pop();
+    const {classificationId} = URN.toURL(item?.urn);
+
+    item.id = classificationId || item._links?.self?.href?.split('/').pop();
     // TODO use fallback and loader
     const {metadata, codesWithNotes} = useClassification(item.id);
 
@@ -173,8 +175,8 @@ export const Codes = ({from, to, codes = [], id, include}) => {
 
     return (
         <div style={{backgroundColor: 'AliceBlue'}} className='panel'>
-            <div className="ssb-checkbox-group">
-                <div className="checkbox-group-header">{t('Codes')}
+            <div className='ssb-checkbox-group'>
+                <div className='checkbox-group-header'>{t('Codes')}
                     {from && to
                         ? ` ${t('from to', { from, to })}:`
                         : from || to ? ` ${t('at', { date: from || to})}:`
@@ -224,7 +226,7 @@ export const CodeInfo = ({id, item, onChange}) => {
     return (
         <>
             <div style={{display: 'flex'}}>
-                <div className="ssb-checkbox">
+                <div className='ssb-checkbox'>
                     <input id={`${item.code}-${id}`}
                            type='checkbox' name='include'
                            checked={item.included}

--- a/src/components/subsetDraft/Classification.jsx
+++ b/src/components/subsetDraft/Classification.jsx
@@ -88,7 +88,7 @@ export const Classification = ({item = {}, update, remove, from, to}) => {
     return (
         <>
             <div style={{display: 'flex'}}>
-                <div style={{width: '400px'}}>{item.name}</div>
+                <div style={{width: '400px'}}>{item.name || metadata.name}</div>
 
                 <button onClick={() => item.error && setExpander(toggle.alert())}>
                     <Alert color={item.error ? 'orange' : 'transparent'}/>

--- a/src/components/subsetDraft/SubsetCodes.jsx
+++ b/src/components/subsetDraft/SubsetCodes.jsx
@@ -24,7 +24,7 @@ export const SubsetCodes = ({subset}) => {
             .find(d => d.administrativeDetailType === 'ORIGIN')
             .values.forEach(v => subset.dispatch({
                 action: 'classifications_prepend_included',
-                data: { urn: v, included: true }
+                data: [{ urn: v, included: true }]
             }))
     }
 

--- a/src/components/subsetDraft/SubsetCodes.jsx
+++ b/src/components/subsetDraft/SubsetCodes.jsx
@@ -19,6 +19,15 @@ export const SubsetCodes = ({subset}) => {
     const from = subset.draft.validFrom?.substr(0, 10);
     const to = subset.draft.validUntil?.substr(0, 10);
 
+    if (!subset.draft.classifications || subset.draft.classifications.length === 0) {
+        subset.draft.administrativeDetails
+            .find(d => d.administrativeDetailType === 'ORIGIN')
+            .values.forEach(v => subset.dispatch({
+                action: 'classifications_prepend_included',
+                data: { urn: v, included: true }
+            }))
+    }
+
     const [searchValues, setSearchValues] = useState([]); // list of classification names
     const [searchResult, setSearchResult] = useState([]); // list of classifications with codes found
     

--- a/src/components/subsetDraft/SubsetCodes.jsx
+++ b/src/components/subsetDraft/SubsetCodes.jsx
@@ -25,7 +25,7 @@ export const SubsetCodes = ({subset}) => {
             .values.forEach(v => subset.dispatch({
                 action: 'classifications_prepend_included',
                 data: [{ urn: v, included: true }]
-            }))
+            }));
     }
 
     const [searchValues, setSearchValues] = useState([]); // list of classification names

--- a/src/components/subsetDraft/SubsetPublish.jsx
+++ b/src/components/subsetDraft/SubsetPublish.jsx
@@ -53,7 +53,6 @@ function preparePayload(draft) {
         .values;
 
     draft.classifications.forEach(classification => {
-        console.log({classification});
         codes.push(...classification.codes.filter(c => c.included));
 
         const id = classification.id || classification._links.self.href.split('/').pop();

--- a/src/components/subsetDraft/SubsetPublish.jsx
+++ b/src/components/subsetDraft/SubsetPublish.jsx
@@ -48,10 +48,18 @@ export const SubsetPublish = ({subset}) => {
 // TODO: move the logic to useSubset
 function preparePayload(draft) {
     const codes = [];
-    draft.classifications.map(classification =>
-        codes.push(...classification.codes
-            .filter(c => c.included)
-        ));
+    const origin = draft.administrativeDetails
+        .find(d => d.administrativeDetailType === 'ORIGIN')
+        .values;
+
+    draft.classifications.forEach(classification => {
+        console.log({classification});
+        codes.push(...classification.codes.filter(c => c.included));
+
+        const id = classification.id || classification._links.self.href.split('/').pop();
+        const urn = `urn:klass-api:classifications:${id}`;
+        !origin.includes(urn) && origin.push(urn);
+    });
 
     return {
         createdBy: draft.createdBy,

--- a/src/controllers/klass-api.jsx
+++ b/src/controllers/klass-api.jsx
@@ -26,6 +26,33 @@ export const URN = {
                 : `${klassApiServiceEndpoint}/${service}/${id}/codesAt.json?date=${from || to}&selectCodes=${code}`
             };
         }
+
+        const classificationPattern = /urn:klass-api:classifications:[0-9]+/i;
+
+        if (classificationPattern.test(urn)) {
+            const [,,service,id] = urn.split(':');
+
+            if (from || to) {
+                return {
+                    service,
+                    classificationId: id,
+                    path: from && to
+                        ? `/${service}/${id}/codes.json?from=${from}&to=${to}`
+                        : `/${service}/${id}/codesAt.json?date=${from || to}`,
+                    url: from && to
+                        ? `${klassApiServiceEndpoint}/${service}/${id}/codes.json?from=${from}&to=${to}`
+                        : `${klassApiServiceEndpoint}/${service}/${id}/codesAt.json?date=${from || to}`
+                };
+            } else {
+                return {
+                    service,
+                    classificationId: id,
+                    path: `/${service}/${id}`,
+                    url: `${klassApiServiceEndpoint}/${service}/${id}`
+                };
+            }
+        }
+
         return {};
     }
 };

--- a/src/utils/useSubset.jsx
+++ b/src/utils/useSubset.jsx
@@ -70,9 +70,11 @@ export const useSubset = (init =  {
                 return  {...state, classifications: data};
             }
             case 'classifications_prepend_included': {
-                 const included = data.filter(item => !state.classifications.includes(item) && (item.included
-                    || item.codes.find(code => code.included)));
-                return  {...state, classifications: [...included, ...state.classifications]};
+                 const included = data.filter(item => !state.classifications?.includes(item) && (item.included
+                    || item.codes?.find(code => code.included)));
+                return  state.classifications
+                    ? {...state, classifications: [...included, ...state.classifications]}
+                    : {...state, classifications: [...included]};
             }
             case 'classifications_remove_excluded': {
                 return  {...state, classifications: state.classifications.filter(c => c.included)};


### PR DESCRIPTION
Before sending a new subset to the service, the administrative detail of type 'ORIGIN' is filled with URNs based on chosen classifications. #105 

How to test:
1. create a new subset 
2. on the "Review and Publish" page check if the subset's JSON has administrative detail of type 'ORIGIN' filled correctly.