### PR TITLE
Console log to see the explicit data a saved version is updated to.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "klass-subsets-webclient",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "description": "A webclient application to communicate with Klass subsets service REST API in order to create and update classification subsets of codes.",
   "repository": {
     "type": "git",

--- a/src/models/subset/versionsControl.js
+++ b/src/models/subset/versionsControl.js
@@ -30,7 +30,7 @@ export const versionable = (state = {}) => ({
     },
 
     syncVersion(updatedVersion = {}, tempId = '') {
-        // console.debug('syncVersion', updatedVersion);
+        console.debug('syncVersion', updatedVersion);
 
         if (updatedVersion?.subsetId !== state?.id) return;
 


### PR DESCRIPTION
To test: 
1. save a version the way it usually fails with Chrome Dev Tools on with Console tab. 
2. when successfully saved check the 'syncVersion, updatedVersion' console output, verify that the name is a String and not an object.
3. (Do the same chack in the Network tab of the Chrome Dev Tools. The POST/PUT response has to be checked.
4. then go to "Back to review".
If [obj][obj][obj] is presant, check {newState} to verify is name objects are multilingual.
Try to refresh the page and see if the [obj][obj][obj] is still present.