### PR TITLE
Bump next version to 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "klass-subsets-client",
-  "version": "1.0.8",
+  "version": "1.1.1",
   "description": "A webclient application to communicate with Klass subsets service REST API in order to create and update classification subsets of codes.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Version 1.1.0 is released, but the version number is displayed incorrectly. This should be fixed in version 1.1.1.